### PR TITLE
Generalize zshrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -24,4 +24,4 @@ inoremap jk <ESC>
 let mapleader = " "
 
 " Map system keyboard to Vim's paste buffer
-set clipboard=unnamedplus
+set clipboard=unnamed

--- a/.zshrc
+++ b/.zshrc
@@ -2,25 +2,37 @@
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH=/Users/smorton/.oh-my-zsh
+export ZSH="$HOME/.oh-my-zsh"
 
-# Set name of the theme to load. Optionally, if you set this to "random"
-# it'll load a random theme each time that oh-my-zsh is loaded.
-# See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time oh-my-zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="theunraveler"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in $ZSH/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 
-# Uncomment the following line to use hyphen-insensitive completion. Case
-# sensitive completion must be off. _ and - will be interchangeable.
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
 HYPHEN_INSENSITIVE="true"
 
-# Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
+# Uncomment one of the following lines to change the auto-update behavior
+# zstyle ':omz:update' mode disabled  # disable automatic updates
+# zstyle ':omz:update' mode auto      # update automatically without asking
+# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
 
 # Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
+# zstyle ':omz:update' frequency 13
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
 
 # Uncomment the following line to disable colors in ls.
 # DISABLE_LS_COLORS="true"
@@ -32,6 +44,9 @@ HYPHEN_INSENSITIVE="true"
 # ENABLE_CORRECTION="true"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
 COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to disable marking untracked files
@@ -41,22 +56,23 @@ COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
 # HIST_STAMPS="mm/dd/yyyy"
 
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git brew z tmux)
+plugins=(git brew z tmux poetry)
 
 source $ZSH/oh-my-zsh.sh
-
-# Include z
-. ~/.oh-my-zsh/plugins/z/z.sh
 
 # User configuration
 
@@ -75,9 +91,6 @@ source $ZSH/oh-my-zsh.sh
 # Compilation flags
 # export ARCHFLAGS="-arch x86_64"
 
-# ssh
-# export SSH_KEY_PATH="~/.ssh/rsa_id"
-
 # Set personal aliases, overriding those provided by oh-my-zsh libs,
 # plugins, and themes. Aliases can be placed here, though oh-my-zsh
 # users are encouraged to define aliases within the ZSH_CUSTOM folder.
@@ -87,43 +100,24 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
-# Make it easier to reset the shell.
+# ================ Setup Tools ================
+
+# Make poetry work
+export PATH="$HOME/.poetry/bin:$PATH"
+fpath+=~/.zfunc
+
+# Pyenv Setup
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+# ================ Convenience ================
+
+# Easier terminal nav
+alias zshrc="vim ~/.zshrc"
 alias rs="source ~/.zshrc && echo 'zsh reloaded'"
 
-# ==================  Local Stuff ===================
+# Make it easier to find commands in command line history
+alias forgot="history | grep"
 
-# Make it easier to get to the github shell.
-alias gitpath='cd ~/code/git'
-
-# added by Anaconda2 4.4.0 installer
-# export PATH="/Users/smorton/anaconda/bin:$PATH"  # commented out by conda initialize
-
-# Set browser =
-
-# make it easy to start a python3 notebook
-alias jupyter_notebook='source activate py36; jupyter notebook'
-
-# Easily connect to a remote Jupyter server
-function jupyter_ssh = {
-    echo "Please enter DNS address:"
-    read dns_address
-    open http://$dns_address:8888/
-}
-
-# >>> conda initialize >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/smorton/anaconda/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/Users/smorton/anaconda/etc/profile.d/conda.sh" ]; then
-        . "/Users/smorton/anaconda/etc/profile.d/conda.sh"
-    else
-        export PATH="/Users/smorton/anaconda/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda initialize <<<
-
-# Make Conda Update Work
-unset SUDO_UID SUDO_GID SUDO_USER
+# Load local setup
+. ~/.localrc


### PR DESCRIPTION
Setting up the zshrc so it's more portable.  Configs specific to a device can be stored in a `.localrc` file in the root directory.

Also fixing an issue with yanking and copying in vim.